### PR TITLE
Use configured repeater timeout

### DIFF
--- a/includes/classes/SVXLink.php
+++ b/includes/classes/SVXLink.php
@@ -204,13 +204,17 @@ class SVXLink {
 
 	public function build_tx($curPort, $curPortType = 'GPIO') {
 		$audio_dev = explode("|", $this->portsArray[$curPort]['txAudioDev']);
+		$repeater_timeout = '300';
+		if (isset($this->settingsArray['repeaterTimeoutSec']) && is_numeric($this->settingsArray['repeaterTimeoutSec'])) {
+			$repeater_timeout = $this->settingsArray['repeaterTimeoutSec'];
+		}
 
 		$tx_array['TX_Port'.$curPort] = [
 		'TYPE' => 'Local',
 		'AUDIO_DEV' => $audio_dev[0],
 		'AUDIO_CHANNEL' => $audio_dev[1],
 		'PTT_HANGTIME' => ($this->settingsArray['txTailValueSec'] * 1000),
-		'TIMEOUT' => '300',
+		'TIMEOUT' => $repeater_timeout,
 		'TX_DELAY' => '50',
 		];
 


### PR DESCRIPTION
Fixes #107.

This updates SVXLink TX config generation to use the saved repeaterTimeoutSec setting instead of always emitting TIMEOUT=300.

Validation:
- git diff --check passed
- php -l includes/classes/SVXLink.php passed