### PR TITLE
Require whole-minute ID intervals

### DIFF
--- a/identification.php
+++ b/identification.php
@@ -10,7 +10,7 @@ if ((!isset($_SESSION['username'])) || (!isset($_SESSION['userID']))){
 // --------------------------------------------------------
 
 $customJS = 'page-identification.js, orp-audio-player.js, dropzone.js, upload-file.js, morse-resampler.js, morse-XAudioServer.js, morse.js, morse-main.js'; // 'file1.js, file2.js, ... '
-$customCSS = 'page-identification.css, orp-audio-player.css, upload-file.css'; // 'file1.css, file2.css, ... '
+$customCSS = 'page-identification.css, orp-audio-player.css, upload-file.css'; // 'file1.css, ... '
 
 include('includes/header.php');
 
@@ -58,7 +58,7 @@ $identificationAudio = $AudioFiles->get_audio_filesJSON('identification');
 						  <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="<?=_('...')?>"></i>
                         </label>
                         <div class="col-md-6 col-sm-9 col-xs-7">
-                          <input type="number" id="ID_Short_IntervalMin" name="ID_Short_IntervalMin" class="form-control" value="<?= $settings['ID_Short_IntervalMin'] ?>" placeholder="<?=_('Minutes')?>" required>
+                          <input type="number" min="1" step="1" id="ID_Short_IntervalMin" name="ID_Short_IntervalMin" class="form-control" value="<?= $settings['ID_Short_IntervalMin'] ?>" placeholder="<?=_('Minutes')?>" required>
                         </div>
                       </div>
 
@@ -127,7 +127,7 @@ $identificationAudio = $AudioFiles->get_audio_filesJSON('identification');
 						  <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="<?=_('The number of minutes between long identifications. The purpose of the long identification is to transmit some more information about the station. A good value for a repeater is every 60 minutes.')?>"></i>
                         </label>
                         <div class="col-md-6 col-sm-9 col-xs-7">
-                          <input id="ID_Long_IntervalMin" name="ID_Long_IntervalMin" type="number" class="form-control" value="<?= $settings['ID_Long_IntervalMin'] ?>" placeholder="<?=_('Minutes')?>">
+                          <input id="ID_Long_IntervalMin" name="ID_Long_IntervalMin" type="number" min="1" step="1" class="form-control" value="<?= $settings['ID_Long_IntervalMin'] ?>" placeholder="<?=_('Minutes')?>">
                         </div>
                       </div>
 

--- a/identification.php
+++ b/identification.php
@@ -10,7 +10,7 @@ if ((!isset($_SESSION['username'])) || (!isset($_SESSION['userID']))){
 // --------------------------------------------------------
 
 $customJS = 'page-identification.js, orp-audio-player.js, dropzone.js, upload-file.js, morse-resampler.js, morse-XAudioServer.js, morse.js, morse-main.js'; // 'file1.js, file2.js, ... '
-$customCSS = 'page-identification.css, orp-audio-player.css, upload-file.css'; // 'file1.css, ... '
+$customCSS = 'page-identification.css, orp-audio-player.css, upload-file.css'; // 'file1.css, file2.css, ... '
 
 include('includes/header.php');
 


### PR DESCRIPTION
Fixes #25.

This updates the identification settings form so the short and long ID interval fields only accept whole-minute values of at least 1 minute.

Validation:
- Verified the updated branch content includes min="1" and step="1" on both ID interval inputs.
- php -l identification.php passed