### PR TITLE
Remove generated module config on delete

### DIFF
--- a/includes/classes/Modules.php
+++ b/includes/classes/Modules.php
@@ -520,6 +520,12 @@ class Modules {
 			}
 		}
 
+		// generated module configuration
+		$svxlink_module_config_path = '/etc/svxlink/svxlink.d/Module' . $svxlink_name . '.conf';
+		if (file_exists($svxlink_module_config_path) || is_link($svxlink_module_config_path)) {
+			unlink($svxlink_module_config_path);
+		}
+
 		### Check for SVXLink Sounds and remove ###
 
 		$svxlink_sounds_path = $this->svxlink_sounds . $svxlink_name;


### PR DESCRIPTION
Fixes #69.

This removes the generated SVXLink module config file when an add-on module is deleted. Module config generation writes files such as /etc/svxlink/svxlink.d/Module<Name>.conf, but the delete path only removed linked SVXLink components, sounds, the module directory, GPIO rows, and the database row.

Validation:
- Reviewed the module config generation path and module delete path.
- Confirmed the PR diff is limited to includes/classes/Modules.php.
- git diff --check passed
- php -l includes/classes/Modules.php passed