### PR TITLE
Fix setup wizard back navigation

### DIFF
--- a/wizard/index.php
+++ b/wizard/index.php
@@ -89,11 +89,10 @@ $wizardSettingsArray = json_decode($wizardSettingsJSON, false);
                         </li>
                       </ul>
 
-<form id="wizardForm">
+<form id="wizardForm" novalidate>
 <? ################################################################################ ?>
 
-<!-- <div id="step-1"> -->
-<div id="step-3">
+<div id="step-1">
 	<h3 class="StepTitle"><strong><?=_('Step 1')?></strong> - <?=_('Welcome to OpenRepeater')?></h3>
 
 	<p><?=_('Welcome to the OpenRepeater setup wizard. This wizard will guide you through the essential settings to get your OpenRepeater controller up and running. It will not set all of the settings and it will set many to defaults. Note that none of your entries will be applied until you have completed the wizard, applied your changes, and rebuilt and restart the controller. Any other setting you will be able to modify after the controller is setup.')?></p>
@@ -151,8 +150,7 @@ $wizardSettingsArray = json_decode($wizardSettingsJSON, false);
 
 <? ################################################################################ ?>
 
-<!--                        <div id="step-3"> -->
-                       <div id="step-1">
+                       <div id="step-3">
                         <h3 class="StepTitle"><strong><?=_('Step 3')?></strong> - <?=_('Setup Hardware')?></h3>
 
 


### PR DESCRIPTION
Fixes #53.

This updates the setup wizard markup so the Step 1 and Step 3 anchors point to the matching content panels. The wizard form also opts out of native whole-form validation so backward navigation is not blocked by incomplete fields while moving back to a previous step.

Validation:
- git diff --check passed
- verified wizard step anchors #step-1 through #step-5 each have matching content panels
- php -l wizard/index.php passed